### PR TITLE
Add padding to start and end of forecast for mobile devices.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,6 +44,15 @@ p {
   margin-bottom: 4px;
 }
 
+.forecast-window {
+  padding-inline-start: calc((100vw - 300px) / 2);
+  padding-inline-end: calc((100vw - 300px) / 2);
+  @media (min-width: 768px) {
+    padding-inline-start: unset;
+    padding-inline-end: unset;  
+  }
+}
+
 .nav {
   position: sticky;
   top: 0px;

--- a/src/lib/my-weather-app.tsx
+++ b/src/lib/my-weather-app.tsx
@@ -87,9 +87,9 @@ const MyWeatherApp: React.FC = () => {
       </div>
       <div className="w-full justify-center text-center">Elevation: {userElevation?.value} {userElevation?.unitCode.replace("wmoUnit:", "")}</div>
       
-      <div className="relative grid grid-flow-col grid-rows-2 overflow-auto snap-x md:grid-flow-row md:grid-cols-2 gap-4">
+      <div className="forecast-window grid grid-flow-col grid-rows-2 overflow-auto snap-x md:grid-flow-row md:grid-cols-2 gap-4">
         {forecast.map(period => (
-          <div className="relative w-[290px] h-[200px] md:justify-self-center rounded-2xl p-2 snap-center snap-mandatory border" key={`${period.number}-outer-div`}>
+          <div className="w-[300px] h-[200px] md:justify-self-center rounded-2xl p-2 snap-center snap-mandatory border" key={`${period.number}-outer-div`}>
             <div>
             {period.name}
             </div>


### PR DESCRIPTION
Adding padding to the start and end of the forecast window on mobile devices to cent first and last forecast columns. Larger screens has this unset.